### PR TITLE
get: Die when return value of getCustomIcon is nonzero

### DIFF
--- a/bin/fileicon
+++ b/bin/fileicon
@@ -464,9 +464,7 @@ case $cmd in
     (( quiet )) || echo "Custom icon removed from '$targetFileOrFolder'."
     ;;
   'get')
-    getCustomIcon "$targetFileOrFolder" "$outFile"
-    ec=$?
-    (( ec <= 1 )) || die
+    getCustomIcon "$targetFileOrFolder" "$outFile" || die
     (( quiet )) || { [[ $outFile != '/dev/stdout' ]] && echo "Custom icon extracted to '$outFile'."; }
     exit $ec
     ;;


### PR DESCRIPTION
There are two cases where the return value of `getCustomIcon` could be 1:
- The custom icon file doesn't exist;
- The custom icon file exists but contains no icon resource.

Either way it's a failure and `Custom icon extracted to ...' shouldn't be printed.
