### PR TITLE
Allow test or get when target is readable but not writable

### DIFF
--- a/bin/fileicon
+++ b/bin/fileicon
@@ -416,9 +416,9 @@ esac
 # Target file or folder.
 targetFileOrFolder=$1 imgFile= outFile=
 [[ -f $targetFileOrFolder || -d $targetFileOrFolder ]] || die "Target not found or neither file nor folder: '$targetFileOrFolder'"
-# Make sure the target file/folder is readable, and, unless only extraction is requested, writeable too.
+# Make sure the target file/folder is readable, and, unless only testing or extraction is requested, writeable too.
 [[ -r $targetFileOrFolder ]] || die "Cannot access '$targetFileOrFolder': you do not have read permissions."
-[[ $cmd == 'extract' || -w  $targetFileOrFolder ]] || die "Cannot modify '$targetFileOrFolder': you do not have write permissions."
+[[ $cmd == 'test' || $cmd == 'get' || -w  $targetFileOrFolder ]] || die "Cannot modify '$targetFileOrFolder': you do not have write permissions."
 
 # Other operands, if any, and their number.
 valid=0

--- a/bin/fileicon
+++ b/bin/fileicon
@@ -39,7 +39,7 @@ openUrl() {
       ;;
     *) # Otherwise, assume a Freedesktop-compliant OS, which includes many Linux distros, PC-BSD, OpenSolaris, ...
       cmd=( xdg-open "$url" )
-      ;; 
+      ;;
   esac
   "${cmd[@]}" || { echo "Cannot locate or failed to open default browser; please go to '$url' manually." >&2; return 1; }
 }
@@ -51,7 +51,7 @@ printManPageSource() {
 
 # Opens the man page, if installed; otherwise, tries to display the embedded Markdown-formatted man-page source; if all else fails: tries to display the man page online.
 openManPage() {
-  local pager embeddedText 
+  local pager embeddedText
   if ! man 1 "$kTHIS_NAME" 2>/dev/null; then
     # 2nd attempt: if present, display the embedded Markdown-formatted man-page source
     embeddedText=$(printManPageSource)
@@ -62,7 +62,7 @@ openManPage() {
     else # 3rd attempt: open the the man page on the utility's website
       openUrl "${kTHIS_HOMEPAGE}/doc/${kTHIS_NAME}.md"
     fi
-  fi  
+  fi
 }
 
 # Prints the contents of the synopsis chapter of the embedded Markdown-formatted man-page source for quick reference.
@@ -166,7 +166,7 @@ patchByteInByteString() {
   else
       patchedByte=$byteSpec
   fi
-      
+
   printf '%s%s%s' "$charsBefore" "$patchedByte" "$charsAfter"
 }
 
@@ -212,8 +212,8 @@ setCustomIcon() {
     # Create the special, hidden file inside the folder that will store the icon in its resource fork.
     targetFileWithResourceFork=${fileOrFolder}/$kFILENAME_FOLDERCUSTOMICON
     : > "$targetFileWithResourceFork" || return
-    # Assign the com.apple.FinderInfo extended attribute with values that identify the file as 
-    # both hidden from Finder and as a custom-icon file for the enclosing folder. 
+    # Assign the com.apple.FinderInfo extended attribute with values that identify the file as
+    # both hidden from Finder and as a custom-icon file for the enclosing folder.
     xattr -wx com.apple.FinderInfo "$kFI_BYTES_CUSTOMICONFILEFORFOLDER" "$targetFileWithResourceFork" || return
   else
     targetFileWithResourceFork=$fileOrFolder
@@ -282,7 +282,7 @@ removeCustomIcon() {
   if [[ -d $fileOrFolder ]]; then
     rm -f "${fileOrFolder}/${kFILENAME_FOLDERCUSTOMICON}"
   else
-    if hasIconsResource "$fileOrFolder"; then  
+    if hasIconsResource "$fileOrFolder"; then
       xattr -d com.apple.ResourceFork "$fileOrFolder"
     fi
   fi
@@ -327,7 +327,7 @@ kFILENAME_FOLDERCUSTOMICON=$'Icon\r'
 # com.apple.FinderInfo
 kFI_BYTES_BLANK='0000000000000000000000000000000000000000000000000000000000000000'
 
-# The hex dump form of the full 32 bytes that Finder assigns to the hidden $'Icon\r' 
+# The hex dump form of the full 32 bytes that Finder assigns to the hidden $'Icon\r'
 # file whose com.apple.ResourceFork extended attribute contains the icon image data for the enclosing folder.
 # The first 8 bytes spell out the magic literal 'iconMACS'; they are followed by the invisibility flag, '40' in the 9th byte, and '10' (?? specifying what?)
 # in the 10th byte.
@@ -388,7 +388,7 @@ while (( $# )); do
     if [[ $1 == '--' ]]; then
       shift; operands+=( "$@" ); break
     elif (( allowOptsAfterOperands )); then
-      operands+=( "$1" ) # continue 
+      operands+=( "$1" ) # continue
     else
       operands=( "$@" )
       break
@@ -502,7 +502,7 @@ exit 0
 #     - For better plain-text rendering, leave an empty line after a heading
 #       marked-man will remove it from the ROFF version.
 #     - The first heading must be a level-1 heading containing the utility
-#       name and very brief description; append the manual-section number 
+#       name and very brief description; append the manual-section number
 #       directly to the CLI name; e.g.:
 #         # foo(1) - does bar
 #     - The 2nd, level-2 heading must be '## SYNOPSIS' and the chapter's body
@@ -513,7 +513,7 @@ exit 0
 #         in angle brackets; e.g., '<foo>'
 #     - All other headings should be level-2 headings in ALL-CAPS.
 #   - TEXT
-#      - Use NO indentation for regular chapter text; if you do, it will 
+#      - Use NO indentation for regular chapter text; if you do, it will
 #        be indented further than list items.
 #      - Use 4-space indentation, as usual, for code blocks.
 #      - Markup character-styling markup translates to ROFF rendering as follows:
@@ -559,72 +559,72 @@ Standard options: `--help`, `--man`, `--version`, `--home`
 
 ## DESCRIPTION
 
-`<fileOrFolder>` is the file or folder whose custom icon should be managed.  
-Note that symlinks are followed to their (ultimate target); that is, you  
-can only assign custom icons to regular files and folders, not to symlinks  
+`<fileOrFolder>` is the file or folder whose custom icon should be managed.
+Note that symlinks are followed to their (ultimate target); that is, you
+can only assign custom icons to regular files and folders, not to symlinks
 to them.
 
-`<imageFile>` can be an image file of any format supported by the system.  
+`<imageFile>` can be an image file of any format supported by the system.
 It is converted to an icon and assigned to `<fileOrFolder>`.
 
-`<iconOutputFile>` specifies the file to extract the custom icon to:  
-Defaults to the filename of `<fileOrFolder>` with extension `.icns` appended.  
-If a value is specified, extension `.icns` is appended, unless already present.  
-Either way, extraction fails if the target file already exists; use `-f` to  
-override.  
-Specify `-` to extract to stdout.  
+`<iconOutputFile>` specifies the file to extract the custom icon to:
+Defaults to the filename of `<fileOrFolder>` with extension `.icns` appended.
+If a value is specified, extension `.icns` is appended, unless already present.
+Either way, extraction fails if the target file already exists; use `-f` to
+override.
+Specify `-` to extract to stdout.
 
-Command `test` signals with its exit code whether a custom icon is set (0)  
+Command `test` signals with its exit code whether a custom icon is set (0)
 or not (1); any other exit code signals an unexpected error.
 
 **Options**:
 
-  * `-f`, `--force`  
-    When getting (extracting) a custom icon, forces replacement of the  
+  * `-f`, `--force`
+    When getting (extracting) a custom icon, forces replacement of the
     output file, if it already exists.
 
-  * `-q`, `--quiet`  
-    Suppresses output of the status information that is by default output to  
-    stdout.  
+  * `-q`, `--quiet`
+    Suppresses output of the status information that is by default output to
+    stdout.
     Note that errors and warnings are still printed to stderr.
 
 ## NOTES
 
-Custom icons are stored in extended attributes of the HFS+ filesystem.  
-Thus, if you copy files or folders to a different filesystem that doesn't  
-support such attributes, custom icons are lost; for instance, custom icons  
+Custom icons are stored in extended attributes of the HFS+ filesystem.
+Thus, if you copy files or folders to a different filesystem that doesn't
+support such attributes, custom icons are lost; for instance, custom icons
 cannot be stored in a Git repository.
 
-To determine if a give file or folder has extended attributes, use  
+To determine if a give file or folder has extended attributes, use
 `ls -l@ <fileOrFolder>`.
 
-When setting a custom icon, the source image is resized to 128 x 128 pixels  
-and stored as a single icon, which the system resizes dynamically, depending  
-on context.  
-Currently, even if the source image file is itself an `.icns` file that  
-contains multiple icons with distinct resolutions, only the 128 x 128 icon  
+When setting a custom icon, the source image is resized to 128 x 128 pixels
+and stored as a single icon, which the system resizes dynamically, depending
+on context.
+Currently, even if the source image file is itself an `.icns` file that
+contains multiple icons with distinct resolutions, only the 128 x 128 icon
 is assigned.
 
 ## STANDARD OPTIONS
 
 All standard options provide information only.
 
-* `-h, --help`  
+* `-h, --help`
   Prints the contents of the synopsis chapter to stdout for quick reference.
 
-* `--man`  
-  Displays this manual page, which is a helpful alternative to using `man`, 
+* `--man`
+  Displays this manual page, which is a helpful alternative to using `man`,
   if the manual page isn't installed.
 
-* `--version`  
+* `--version`
   Prints version information.
-  
-* `--home`  
+
+* `--home`
   Opens this utility's home page in the system's default web browser.
 
 ## LICENSE
 
-For license information and more, visit the home page by running  
+For license information and more, visit the home page by running
 `fileicon --home`
 
 EOF_MAN_PAGE


### PR DESCRIPTION
Test or get should not need write permissions. On the other hand, I don't see a subcommand named "extract". Might be an outdated name.

I also removed trailing whitespace along the way.
